### PR TITLE
Add a GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    if: github.repository == 'rmyorston/busybox-w32' || github.repository == 'dscho/busybox-w32'
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: git-for-windows/setup-git-for-windows-sdk@v0
+      with:
+        flavor: build-installers # this includes all the required tools
+    - name: restrict PATH to Git for Windows' SDK (and Windows)
+      shell: bash
+      run: echo 'PATH=/mingw64/bin:/usr/bin/:/c/Windows/system32' >>$GITHUB_ENV
+    - name: mingw64_defconfig
+      shell: bash
+      run: |
+        # We do not _actually_ cross-compile
+        sed -i 's/^\(CONFIG_CROSS_COMPILER_PREFIX=\).*/\1""/' configs/mingw*
+
+        make -j$(nproc) mingw64_defconfig
+    - name: build busybox.exe
+      shell: bash
+      run: make -j$(nproc) busybox.exe
+    - name: upload busybox artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: busybox
+        path: busybox.exe

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Config.in
 #
 # Never ignore these
 #
+!.github
 !.gitignore
 
 #


### PR DESCRIPTION
This not only ensures that BusyBox-w32 can be built directly on Windows
(in an MSYS2 environment using mingw-w64-gcc), it also ensures that the
testsuite runs and passes.

Note: we need the `build-installers` flavor of Git for Windows' SDK
because the smaller variants lack tools like `bzip2` and `od` that are
required by BusyBox' own build (apparently they are required when
splitting the config, for some reason).

Also note that this workflow is disabled by default, except on
https://github.com/rmyorston/busybox-w32 (and this developer's fork). It
was determined by the BusyBox-w32 maintainer that the workflow should be
opt-in (GitHub workflows are opt-out). Users who want the workflow to
run in their fork need to edit the workflow definition.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>